### PR TITLE
Delete first built docker image before building the second image

### DIFF
--- a/lib/htcht/cli/rails/rails.rb
+++ b/lib/htcht/cli/rails/rails.rb
@@ -107,6 +107,7 @@ module Htcht
             gsub_file('Dockerfile', "RUN gem install rails", '#RUN gem install rails')
             gsub_file('Dockerfile', '#COPY Gemfile Gemfile.lock ./', 'COPY Gemfile Gemfile.lock ./')
             gsub_file('Dockerfile', '#RUN gem install bundler && bundle install --jobs 20 --retry 5', 'RUN gem install bundler && bundle install --jobs 20 --retry 5')
+            run("docker rmi #{appname.downcase}_app -f")
             run('docker-compose build')
 
             run('docker-compose run app rake db:create')


### PR DESCRIPTION
Delete the first created docker image:
![delete image](https://monosnap.com/file/w7OEjlatHOXGqC1ORrie13R5b4kvux.png)

Leaves use with one image tagged `latest`:
![latest](https://monosnap.com/file/Twt7uaGqnV6SzbRRFJEUnPmSMRIe03.png)